### PR TITLE
On-start handlers JIT Compile & General bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@
 /.vscode
 /Builds
 /YSFreedomServer-v2
+/Tests/csharp-Protoshift-Replay/windy_temp

--- a/HandlerGenerator/HandlerGenerator.csproj
+++ b/HandlerGenerator/HandlerGenerator.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>csharp_Protoshift.Enhanced.Handlers.Generator</RootNamespace>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>YYHEggEgg</Authors>
     <Product>csharp-Protoshift.$(AssemblyName)</Product>
     <Copyright>Copyright (c) 2023 EggEgg</Copyright>

--- a/HandlerGenerator/HandlerGenerator.csproj
+++ b/HandlerGenerator/HandlerGenerator.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/HandlerGenerator/OuterInvoke.cs
+++ b/HandlerGenerator/OuterInvoke.cs
@@ -40,6 +40,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
             if (invokeInfo.StartingNotice != null) Log.Info(invokeInfo.StartingNotice, nameof(OuterInvoke));
             Process? p = Process.Start(startInfo);
             await (p?.WaitForExitAsync() ?? Task.CompletedTask);
+            Log.Verb($"Actual: invoke '{invokeInfo.ProcessPath}'; exitCode={p?.ExitCode}; args='{invokeInfo.CmdLine}'; env='{invokeInfo.WorkingDir}'", nameof(OuterInvoke));
             return p?.ExitCode ?? int.MinValue;
         }
 
@@ -55,7 +56,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
             var exitcode = await InnerRun(invokeInfo);
             if (exitcode != 0 && invokeInfo.AutoTerminateReason != null)
             {
-                Log.Erro($"{invokeInfo.AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                Log.Erro($"{invokeInfo.AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
                 Environment.Exit(autoTerminateCode);
             }
             return exitcode;
@@ -80,12 +81,12 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
             if (rtn[0] != 0 && invokeInfo1.AutoTerminateReason != null)
             {
                 exiting = true;
-                Log.Erro($"{invokeInfo1.AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                Log.Erro($"{invokeInfo1.AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
             }
             if (rtn[1] != 0 && invokeInfo2.AutoTerminateReason != null)
             {
                 exiting = true;
-                Log.Erro($"{invokeInfo2.AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                Log.Erro($"{invokeInfo2.AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
             }
             if (exiting)
             {
@@ -115,17 +116,17 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
             if (rtn[0] != 0 && invokeInfo1.AutoTerminateReason != null)
             {
                 exiting = true;
-                Log.Erro($"{invokeInfo1.AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                Log.Erro($"{invokeInfo1.AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
             }
             if (rtn[1] != 0 && invokeInfo2.AutoTerminateReason != null)
             {
                 exiting = true;
-                Log.Erro($"{invokeInfo2.AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                Log.Erro($"{invokeInfo2.AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
             }
             if (rtn[2] != 0 && invokeInfo3.AutoTerminateReason != null)
             {
                 exiting = true;
-                Log.Erro($"{invokeInfo3.AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                Log.Erro($"{invokeInfo3.AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
             }
             if (exiting)
             {
@@ -155,7 +156,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                 if (rtn[i] != 0 && invokeInfos[i].AutoTerminateReason != null)
                 {
                     exiting = true;
-                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
                 }
             }
             if (exiting)
@@ -186,7 +187,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                 if (rtn[i] != 0 && invokeInfos[i].AutoTerminateReason != null)
                 {
                     exiting = true;
-                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
                 }
             }
             if (exiting)
@@ -217,7 +218,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                 if (rtn[i] != 0 && invokeInfos[i].AutoTerminateReason != null)
                 {
                     exiting = true;
-                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
                 }
             }
             if (exiting)
@@ -248,7 +249,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                 if (rtn[i] != 0 && invokeInfos[i].AutoTerminateReason != null)
                 {
                     exiting = true;
-                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} failed. Exit code is {autoTerminateCode}. ", "OuterInvoke");
+                    Log.Erro($"{invokeInfos[i].AutoTerminateReason} Exit code is {autoTerminateCode}. ", "OuterInvoke");
                 }
             }
             if (exiting)

--- a/HandlerGenerator/OuterInvokeConfig.cs
+++ b/HandlerGenerator/OuterInvokeConfig.cs
@@ -11,7 +11,7 @@
         /// If protoc isn't in the PATH, you can change it to a definitive path.
         /// Not recommend a relative path because the working directory will be changed by the program at the startup. 
         /// </summary>
-        public const string protoc_path = "E:\\Program Files\\Google.Protobuf\\protoc\\bin\\protoc.exe";
+        public const string protoc_path = "protoc";
         /// <summary>
         /// The dotnet runtime CLI from Microsoft. 
         /// If dotnet isn't in the PATH, you can change it to a definitive path.

--- a/HandlerGenerator/OuterInvokeConfig.cs
+++ b/HandlerGenerator/OuterInvokeConfig.cs
@@ -11,7 +11,7 @@
         /// If protoc isn't in the PATH, you can change it to a definitive path.
         /// Not recommend a relative path because the working directory will be changed by the program at the startup. 
         /// </summary>
-        public const string protoc_path = "protoc";
+        public const string protoc_path = "E:\\Program Files\\Google.Protobuf\\protoc\\bin\\protoc.exe";
         /// <summary>
         /// The dotnet runtime CLI from Microsoft. 
         /// If dotnet isn't in the PATH, you can change it to a definitive path.

--- a/HandlerGenerator/Program.cs
+++ b/HandlerGenerator/Program.cs
@@ -764,7 +764,8 @@ internal class Program
             for (int i = 0; i < 6; i++) mergeChanges.Add(new());
         }
         #endregion
-        GenProtoshiftDispatch.Run(cmdData, protoshiftDispatch_filePath, mergeChanges);
+        GenProtoshiftDispatch.Run(cmdData, protoshiftDispatch_filePath, 
+            messageResults, enumResults, mergeChanges);
         recoverbackups.Remove(protoshiftDispatch_filePath);
         #endregion
 

--- a/HandlerGenerator/Program.cs
+++ b/HandlerGenerator/Program.cs
@@ -880,7 +880,7 @@ internal class Program
         }, 2910);
         #region After-builds tasks
         Log.Info($"dotnet build & publish succeeded. Now copying resources...");
-        File.Copy($"./../csharp-Protoshift/config.json", $"{output_path}/config.json");
+        File.Copy($"./../csharp-Protoshift/config.json", $"{output_path}/config.json", true);
         string output_res_dir = $"{output_path}/resources";
         Tools.CopyDir("./../csharp-Protoshift/resources", output_res_dir);
 
@@ -926,7 +926,7 @@ internal class Program
                 {
                     ProcessPath = OuterInvokeGlobalConfig.windows_powershell_path,
                     StartingNotice = $"The custom after-build task (powershell.exe) is starting...",
-                    CmdLine = $"\"{afterbuild_shell}\" \"{Path.GetFullPath(output_path)}\"",
+                    CmdLine = $"-File \"{afterbuild_shell}\" \"{Path.GetFullPath(output_path)}\"",
                     AutoTerminateReason = PublishFailOnAfterBuildTasksFailure
                         ? "The custom after-build task (Windows) failed. " : null,
                 }, 3400);

--- a/HandlerGenerator/ProtobufManage/GitInvoke.cs
+++ b/HandlerGenerator/ProtobufManage/GitInvoke.cs
@@ -69,6 +69,25 @@ internal class GitInvoke
     public string? GetLastCommitTime() =>
         Tools.GetContentFromExecute(OuterInvokeGlobalConfig.git_path, _baseGitDir, "log --pretty=format:\"%cd\" HEAD -1");
 
+    public void SetSafeDirectory()
+    {
+        var targetPath = Path.GetFullPath(_baseGitDir).Replace('\\', '/');
+        ProcessStartInfo startInfo = new(OuterInvokeGlobalConfig.git_path)
+        {
+            Arguments = $"config --global --add safe.directory \"{targetPath}\"",
+        };
+        var p = Process.Start(startInfo);
+        p?.WaitForExit();
+        if (p?.ExitCode != 0)
+        {
+            Log.Warn($"Failed: git config --global --add safe.directory \"{targetPath}\" (exited with {p?.ExitCode}).", nameof(SetSafeDirectory));
+        }
+        else
+        {
+            Log.Info($"Successfully set \"{targetPath}\" as global safe directory.", nameof(SetSafeDirectory));
+        }
+    }
+
     public void Fetch()
     {
         ProcessStartInfo startInfo = new(OuterInvokeGlobalConfig.git_path)

--- a/HandlerGenerator/ProtobufManage/GitProtosManager.cs
+++ b/HandlerGenerator/ProtobufManage/GitProtosManager.cs
@@ -88,7 +88,7 @@ internal class GitProtosManager
     {
         var cloneargs = "clone ";
         if (branch != null) cloneargs += $"--branch {branch} ";
-        cloneargs += $"{remoteUrl_git} {Path.GetFullPath(BaseGitDirectory)}";
+        cloneargs += $"{remoteUrl_git} \"{Path.GetFullPath(BaseGitDirectory)}\"";
 
         ProcessStartInfo startInfo = new(OuterInvokeGlobalConfig.git_path)
         {

--- a/HandlerGenerator/ProtobufManage/GitProtosManager.cs
+++ b/HandlerGenerator/ProtobufManage/GitProtosManager.cs
@@ -24,6 +24,7 @@ internal class GitProtosManager
     {
         _gitInvoke = new(path);
         Logger = Log.GetChannel(protocol_friendlyname);
+        _gitInvoke.SetSafeDirectory();
     }
 
     /// <summary>

--- a/HandlerGenerator/ProtoshiftEx/CodeGenerate/HandlerCodeWriter.cs
+++ b/HandlerGenerator/ProtoshiftEx/CodeGenerate/HandlerCodeWriter.cs
@@ -101,6 +101,20 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
             fi.WriteLine($"return newprotocol;");
             fi.ExitCodeRegion();
             #endregion
+            fi.WriteLine();
+            #region JIT API
+            fi.WriteLine("#region JIT API");
+            WriteNonUserCodeSign(ref fi);
+            fi.WriteLine($"public override NewProtos.{messageName} GetNewShiftToOldJitInstance()");
+            fi.EnterCodeRegion();
+            fi.WriteLine($"NewProtos.{messageName} newprotocol = new();");
+            GenerateCommonFieldsJitAPI(ref fi, oldmessage, newmessage);
+            GenerateMapFieldsJitAPI(ref fi, oldmessage, newmessage);
+            GenerateOneofFieldsJitAPI(ref fi, oldmessage, newmessage);
+            fi.WriteLine($"return newprotocol;");
+            fi.ExitCodeRegion();
+            fi.WriteLine("#endregion");
+            #endregion
             fi.WriteLine("#endregion");
             #endregion
             fi.WriteLine();

--- a/HandlerGenerator/ProtoshiftEx/CodeGenerate/HandlerJitParamters.cs
+++ b/HandlerGenerator/ProtoshiftEx/CodeGenerate/HandlerJitParamters.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace csharp_Protoshift.Enhanced.Handlers.Generator
+{
+    public partial class HandlerCodeWriter
+    {
+        /// <summary>
+        /// Get (code of) a value of <paramref name="fieldType"/>
+        /// to provide for GetNewShiftToOldJitInstance().
+        /// </summary>
+        /// <param name="fieldType"></param>
+        /// <returns></returns>
+        private static string GetTypeJitParamter(string fieldType)
+        {
+            return fieldType switch
+            {
+                "double" => "4.25",
+                "float" => "3.4F",
+                "int32" => "20231024",
+                "int64" => "202411041200",
+                "uint32" => "20231024",
+                "uint64" => "202411041200",
+                "sint32" => "20231024",
+                "sint64" => "202411041200",
+                "fixed32" => "20231024",
+                "fixed64" => "202411041200",
+                "sfixed32" => "20231024",
+                "sfixed64" => "202411041200",
+                "bool" => "true",
+                "string" => "\"miHomo Technology Presents\"",
+                "bytes" => "ByteString.CopyFrom(\"Masquerade of the GIO\", System.Text.Encoding.Default)",
+                _ => $"handler_{fieldType}.GetNewShiftToOldJitInstance()"
+            };
+        }
+    }
+}

--- a/HandlerGenerator/ProtoshiftEx/CodeGenerate/HandlerOneofFieldGenerate.cs
+++ b/HandlerGenerator/ProtoshiftEx/CodeGenerate/HandlerOneofFieldGenerate.cs
@@ -3,7 +3,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
     public partial class HandlerCodeWriter
     {
         /// <summary>
-        /// Generate a line of code that shift the Map Field.
+        /// Generate a line of code that shift the Oneof Field.
         /// </summary>
         /// <param name="fi">The BasicCodeWriter (Generated outside).</param>
         /// <param name="oneofFieldName">The oneof Entry name, the original name from the proto file.</param>
@@ -70,7 +70,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
         }
 
         /// <summary>
-        /// Generate a line of code that shift the Map Field.
+        /// Generate a series of code that shift the Oneof Fields.
         /// </summary>
         /// <param name="fi">The BasicCodeWriter (Generated outside).</param>
         /// <param name="oldmessage">The analyzed old message.</param>
@@ -110,7 +110,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
         }
 
         /// <summary>
-        /// Generate a line of code that shift the skill issued Map Field, but return the object.
+        /// Generate a line of code that shift the skill issued Oneof Field, but return the object.
         /// </summary>
         /// <param name="fi">The BasicCodeWriter (Generated outside).</param>
         /// <param name="oneofFieldName">The oneof Entry name, the original name from the proto file.</param>
@@ -131,5 +131,54 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                     belongToMessageCompileName, baseMessage_friendlyName);
             }
         }
+
+        #region JIT API
+        /// <summary>
+        /// Generate a series of code that assign an value for
+        /// the Protoshift example instance, which is used to
+        /// trigger the JIT process.
+        /// </summary>
+        /// <param name="fi">The BasicCodeWriter (Generated outside).</param>
+        /// <param name="oldmessage">The analyzed old message.</param>
+        /// <param name="newmessage">The analyzed new message.</param>
+        private static void GenerateOneofFieldsJitAPI(ref BasicCodeWriter fi,
+            MessageResult oldmessage, MessageResult newmessage)
+        {
+            var oneofFieldsCollection = CollectionHelper.GetCompareResult(
+                oldmessage.oneofFields, newmessage.oneofFields, OneofResult.NameComparer);
+            foreach (var oneof_pair in oneofFieldsCollection.IntersectItems)
+            {
+                GenerateOneofFieldJitAPI(ref fi, oneof_pair.LeftItem.oneofEntryName, oldmessage.messageName,
+                    oneof_pair.LeftItem, oneof_pair.RightItem,
+                    oldmessage.messageName);
+            }
+        }
+
+        /// <summary>
+        /// Generate a line of code that assign a Oneof Field
+        /// for the Protoshift example instance, which is used
+        /// to trigger the JIT process.
+        /// </summary>
+        /// <param name="fi">The BasicCodeWriter (Generated outside).</param>
+        /// <param name="oneofFieldName">The oneof Entry name, the original name from the proto file.</param>
+        /// <param name="belongToMessageCompileName">The compiled name of the message whom the oneof field belongs to, which can be identified with the compiler.</param>
+        /// <param name="oldoneofField">The analyzed old oneofField.</param>
+        /// <param name="newoneofField">The analyzed new oneofField.</param>
+        /// <param name="baseMessage_friendlyName">Give the param can let the code cope with the case that the message name == field name (compiled field name will add _)</param>
+        private static void GenerateOneofFieldJitAPI(ref BasicCodeWriter fi, string oneofFieldName, string belongToMessageCompileName,
+            OneofResult oldoneofField, OneofResult newoneofField, 
+            string? baseMessage_friendlyName = null)
+        {
+            string fieldName = Tools.GetProtocCompiledName(oneofFieldName) ?? "";
+            if (fieldName == baseMessage_friendlyName) fieldName += '_';
+            var oneofInnerFieldsCollection = CollectionHelper.GetCompareResult(
+                oldoneofField.oneofInnerFields, newoneofField.oneofInnerFields, CommonResult.NameComparer);
+            var oneof_pair = oneofInnerFieldsCollection.IntersectItems.First();
+                    var commonFieldName = oneof_pair.LeftItem.fieldName;
+            GenerateCommonFieldJitAPI(ref fi, commonFieldName,
+                oneof_pair.LeftItem, oneof_pair.RightItem,
+                baseMessage_friendlyName);
+        }
+        #endregion
     }
 }

--- a/HandlerGenerator/ProtoshiftEx/CodeGenerate/ImportTypesCollection.cs
+++ b/HandlerGenerator/ProtoshiftEx/CodeGenerate/ImportTypesCollection.cs
@@ -39,7 +39,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
             /// </summary>
             // public bool importIsMessage;
             /// <summary>
-            /// The name can be identified by the compilier in the global context <para/>
+            /// The name can be identified by the compilier in the global context
             /// (but without NewProtos/OldProtos prefix), <para/>
             /// e.g. ExampleProto2, ExampleProto2.Types.ExampleInnerProto
             /// </summary>

--- a/HandlerGenerator/ProtoshiftEx/OuterDispatchGenerate/GenAskCmdId.cs
+++ b/HandlerGenerator/ProtoshiftEx/OuterDispatchGenerate/GenAskCmdId.cs
@@ -44,7 +44,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                 {
                     fi.WriteLine($"case \"{cmdPair.messageName}\": return {cmdPair.cmdId};");
                 }
-                fi.WriteLine($"default: throw new NotSupportedException(\"Unknown message name or it doesn't have cmd_id.\");");
+                fi.WriteLine($"default: throw new NotSupportedException($\"Unknown message name: {{protoname}} or it doesn't have cmd_id.\");");
                 fi.ExitCodeRegion();
                 fi.ExitCodeRegion();
                 fi.WriteLine("// DON'T INSERT ANY CODE HERE");
@@ -107,7 +107,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                         #endregion
                     }
                 }
-                fi.WriteLine($"default: throw new NotSupportedException(\"The input {identifier} CmdId is unknown.\");");
+                fi.WriteLine($"default: throw new NotSupportedException($\"The input {identifier} CmdId: {{cmdid}} is unknown.\");");
                 fi.ExitCodeRegion();
                 fi.ExitCodeRegion();
                 fi.WriteLine();

--- a/HandlerGenerator/ProtoshiftEx/OuterDispatchGenerate/GenProtoshiftDispatch.cs
+++ b/HandlerGenerator/ProtoshiftEx/OuterDispatchGenerate/GenProtoshiftDispatch.cs
@@ -200,7 +200,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.Generator
                         "byte[] body, int body_offset, int body_length)");
                     break;
                 case ShiftDataType.ReadOnlySpan:
-                    fi.WriteLine($"public static byte[] {method_identifier}(uint cmdid, ReadOnlySpan<byte> head, ReadOnlySpan<byte> body)");
+                    fi.WriteLine($"public static IMessage? {method_identifier}(uint cmdid, ReadOnlySpan<byte> head, ReadOnlySpan<byte> body)");
                     break;
                 case ShiftDataType.ByteString:
                     fi.WriteLine($"public static ByteString {method_identifier}(uint cmdid, ByteString? head, ByteString body)");

--- a/KCP/Kcp/Kcp.csproj
+++ b/KCP/Kcp/Kcp.csproj
@@ -79,7 +79,7 @@
 	</None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
   </ItemGroup>
 
   <!--调试符号配置-->

--- a/NewProtoHandlers/NewProtoHandlers.csproj
+++ b/NewProtoHandlers/NewProtoHandlers.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
   </ItemGroup>
 

--- a/OldProtoHandlers/OldProtoHandlers.csproj
+++ b/OldProtoHandlers/OldProtoHandlers.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
   </ItemGroup>
 

--- a/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto.cs
+++ b/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto.cs
@@ -124,6 +124,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.AEnum = handler_ExampleEnum.GetNewShiftToOldJitInstance();
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -189,10 +199,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
@@ -210,10 +220,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]

--- a/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto.cs
+++ b/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto.cs
@@ -74,6 +74,8 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             return oldprotocol;
         }
 
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override NewProtos.ExampleProto? OldShiftToNew(OldProtos.ExampleProto? oldprotocol)
         {
             if (oldprotocol == null) return null;
@@ -109,6 +111,20 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             #endregion
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override NewProtos.ExampleProto GetNewShiftToOldJitInstance()
+        {
+            NewProtos.ExampleProto newprotocol = new();
+            newprotocol.EgEnum = handler_ExampleEnum.GetNewShiftToOldJitInstance();
+            newprotocol.EgStr = "miHomo Technology Presents";
+            newprotocol.EgProto2.Add("miHomo Technology Presents", handler_ExampleProto2.GetNewShiftToOldJitInstance());
+            newprotocol.AEnum = handler_ExampleEnum.GetNewShiftToOldJitInstance();
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         public bool HasSkillIssue = true;

--- a/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto2.cs
+++ b/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto2.cs
@@ -63,6 +63,18 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.ListStr.AddRange(oldprotocol.ListStr);
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override NewProtos.ExampleProto2 GetNewShiftToOldJitInstance()
+        {
+            NewProtos.ExampleProto2 newprotocol = new();
+            newprotocol.ExBytes = ByteString.CopyFrom("Masquerade of the GIO", System.Text.Encoding.Default);
+            newprotocol.ListStr.Add("miHomo Technology Presents");
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         public bool HasSkillIssue = true;
@@ -151,6 +163,17 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
                 newprotocol.InnerCode = oldprotocol.InnerCode;
                 return newprotocol;
             }
+
+            #region JIT API
+            [System.Diagnostics.DebuggerNonUserCode]
+            [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+            public override NewProtos.ExampleProto2.Types.ExampleInnerProto GetNewShiftToOldJitInstance()
+            {
+                NewProtos.ExampleProto2.Types.ExampleInnerProto newprotocol = new();
+                newprotocol.InnerCode = 20231024;
+                return newprotocol;
+            }
+            #endregion
             #endregion
 
             public bool HasSkillIssue = true;

--- a/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto2.cs
+++ b/ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto2.cs
@@ -74,6 +74,17 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.ListStr.Add("miHomo Technology Presents");
             return newprotocol;
         }
+
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+
+            HandlerExampleInnerProto.GlobalInstance.RunJit();
+            HandlerExampleInnerEnum.GlobalInstance.RunJit();
+        }
         #endregion
         #endregion
 
@@ -89,10 +100,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
@@ -110,10 +121,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
@@ -173,6 +184,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
                 newprotocol.InnerCode = 20231024;
                 return newprotocol;
             }
+            
+            [System.Diagnostics.DebuggerNonUserCode]
+            [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+            public override void RunJit()
+            {
+                var instance = GetNewShiftToOldJitInstance();
+                OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+                OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+                OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+            }
             #endregion
             #endregion
 
@@ -188,10 +209,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             }
             [System.Diagnostics.DebuggerNonUserCode]
             [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
-            public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+            public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
             {
                 var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-                return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+                return rtn;
             }
             [System.Diagnostics.DebuggerNonUserCode]
             [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
@@ -209,10 +230,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             }
             [System.Diagnostics.DebuggerNonUserCode]
             [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
-            public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+            public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
             {
                 var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-                return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+                return rtn;
             }
             [System.Diagnostics.DebuggerNonUserCode]
             [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]

--- a/ProtoshiftHandlers/Example/Generated_std/HandlerInMessage.cs
+++ b/ProtoshiftHandlers/Example/Generated_std/HandlerInMessage.cs
@@ -59,6 +59,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.Code = 20231024;
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -68,10 +78,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length));
             return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
         }
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         public override ByteString NewShiftToOld(ByteString bytes)
         {
@@ -83,10 +93,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length));
             return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
         }
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         public override ByteString OldShiftToNew(ByteString bytes)
         {

--- a/ProtoshiftHandlers/Example/Generated_std/HandlerInMessage.cs
+++ b/ProtoshiftHandlers/Example/Generated_std/HandlerInMessage.cs
@@ -48,6 +48,18 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.Code = oldprotocol.Code;
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override NewProtos.InMessage GetNewShiftToOldJitInstance()
+        {
+            NewProtos.InMessage newprotocol = new();
+            newprotocol.InStr = "miHomo Technology Presents";
+            newprotocol.Code = 20231024;
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         #region Outer bytes invoke

--- a/ProtoshiftHandlers/HandlerBase.cs
+++ b/ProtoshiftHandlers/HandlerBase.cs
@@ -8,6 +8,13 @@ namespace csharp_Protoshift.Enhanced.Handlers
     {
         public abstract TOldProtocol? NewShiftToOld(TNewProtocol? newprotocol);
         public abstract TNewProtocol? OldShiftToNew(TOldProtocol? oldprotocol);
+
+        public abstract TNewProtocol GetNewShiftToOldJitInstance();
+        public virtual void RunJit()
+        {
+            var instance = NewShiftToOld(GetNewShiftToOldJitInstance());
+            OldShiftToNew(instance);
+        }
     }
 
     public abstract class HandlerBase
@@ -25,10 +32,17 @@ namespace csharp_Protoshift.Enhanced.Handlers
     }
 
     public abstract class HandlerEnumBase<TNewProtocol, TOldProtocol>
-        where TNewProtocol : System.Enum
-        where TOldProtocol : System.Enum
+        where TNewProtocol : struct, System.Enum
+        where TOldProtocol : struct, System.Enum
     {
         public abstract TOldProtocol NewShiftToOld(TNewProtocol newprotocol);
         public abstract TNewProtocol OldShiftToNew(TOldProtocol oldprotocol);
+
+        public virtual TNewProtocol GetNewShiftToOldJitInstance() => Enum.GetValues<TNewProtocol>()[0];
+        public virtual void RunJit()
+        {
+            var instance = NewShiftToOld(GetNewShiftToOldJitInstance());
+            OldShiftToNew(instance);
+        }
     }
 }

--- a/ProtoshiftHandlers/HandlerBase.cs
+++ b/ProtoshiftHandlers/HandlerBase.cs
@@ -14,6 +14,17 @@ namespace csharp_Protoshift.Enhanced.Handlers
         {
             var instance = NewShiftToOld(GetNewShiftToOldJitInstance());
             OldShiftToNew(instance);
+            
+            var byteArray = Array.Empty<byte>();
+            var span = ReadOnlySpan<byte>.Empty;
+            var byteString = ByteString.Empty;
+            
+            NewShiftToOld(byteArray);
+            OldShiftToNew(byteArray);
+            NewShiftToOld(span);
+            OldShiftToNew(span);
+            NewShiftToOld(byteString);
+            OldShiftToNew(byteString);
         }
     }
 
@@ -22,12 +33,12 @@ namespace csharp_Protoshift.Enhanced.Handlers
         public virtual byte[] NewShiftToOld(byte[] arr)
             => NewShiftToOld(arr, 0, arr.Length);
         public abstract byte[] NewShiftToOld(byte[] arr, int offset, int length);
-        public abstract byte[] NewShiftToOld(ReadOnlySpan<byte> span);
+        public abstract IMessage? NewShiftToOld(ReadOnlySpan<byte> span);
         public abstract ByteString NewShiftToOld(ByteString bytes);
         public virtual byte[] OldShiftToNew(byte[] arr)
             => OldShiftToNew(arr, 0, arr.Length);
         public abstract byte[] OldShiftToNew(byte[] arr, int offset, int length);
-        public abstract byte[] OldShiftToNew(ReadOnlySpan<byte> span);
+        public abstract IMessage? OldShiftToNew(ReadOnlySpan<byte> span);
         public abstract ByteString OldShiftToNew(ByteString bytes);
     }
 

--- a/ProtoshiftHandlers/ProtoshiftHandlers.csproj
+++ b/ProtoshiftHandlers/ProtoshiftHandlers.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
   </ItemGroup>
 

--- a/ProtoshiftHandlers/SpecialHandlers/CustomHandlers/HandlerUint32PairAndMap.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/CustomHandlers/HandlerUint32PairAndMap.cs
@@ -1,4 +1,5 @@
-﻿using Google.Protobuf.Collections;
+﻿using csharp_Protoshift.Enhanced.Handlers.GeneratedCode;
+using Google.Protobuf.Collections;
 
 namespace csharp_Protoshift.Enhanced.Handlers.CustomHandlers
 {
@@ -52,5 +53,9 @@ namespace csharp_Protoshift.Enhanced.Handlers.CustomHandlers
 
         private static HandlerUint32PairAndMap _globalOnlyInstance = new HandlerUint32PairAndMap();
         public static HandlerUint32PairAndMap GlobalInstance => _globalOnlyInstance;
+
+        private HandlerUint32Pair handler_Uint32Pair = HandlerUint32Pair.GlobalInstance;
+        public NewProtos.Uint32Pair GetNewShiftToOldJitInstance() =>
+            handler_Uint32Pair.GetNewShiftToOldJitInstance();
     }
 }

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerAbilityInvokeEntry.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerAbilityInvokeEntry.cs
@@ -511,21 +511,61 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.TotalTickTime = 4.25;
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override byte[] NewShiftToOld(byte[] arr, int offset, int length)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length)).ToByteArray();
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(span)).ToByteArray();
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length));
+            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
+            return rtn;
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override ByteString NewShiftToOld(ByteString bytes)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(bytes)).ToByteString();
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(bytes));
+            return rtn == null ? ByteString.Empty : rtn.ToByteString();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override byte[] OldShiftToNew(byte[] arr, int offset, int length)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length)).ToByteArray();
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(span)).ToByteArray();
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length));
+            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
+            return rtn;
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override ByteString OldShiftToNew(ByteString bytes)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(bytes)).ToByteString();
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(bytes));
+            return rtn == null ? ByteString.Empty : rtn.ToByteString();
+        }
 
         private static HandlerAbilityInvokeEntry _globalOnlyInstance = new HandlerAbilityInvokeEntry();
         public static HandlerAbilityInvokeEntry GlobalInstance => _globalOnlyInstance;

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerAbilityInvokeEntry.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerAbilityInvokeEntry.cs
@@ -496,6 +496,22 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             }
             return newprotocol;
         }
+
+        #region JIT API
+        public override NewProtos.AbilityInvokeEntry GetNewShiftToOldJitInstance()
+        {
+            NewProtos.AbilityInvokeEntry newprotocol = new();
+            newprotocol.ArgumentType = NewProtos.AbilityInvokeArgument.None;
+            newprotocol.EntityId = 20231024;
+            newprotocol.EventId = 20231024;
+            newprotocol.ForwardPeer = 20231024;
+            newprotocol.ForwardType = handler_ForwardType.GetNewShiftToOldJitInstance();
+            newprotocol.Head = handler_AbilityInvokeEntryHead.GetNewShiftToOldJitInstance();
+            newprotocol.IsIgnoreAuth = true;
+            newprotocol.TotalTickTime = 4.25;
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         public override byte[] NewShiftToOld(byte[] arr, int offset, int length)

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerCombatInvokeEntry.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerCombatInvokeEntry.cs
@@ -187,6 +187,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             }
             return newprotocol;
         }
+
+        #region JIT API
+        public override NewProtos.CombatInvokeEntry GetNewShiftToOldJitInstance()
+        {
+            NewProtos.CombatInvokeEntry newprotocol = new();
+            newprotocol.ArgumentType = NewProtos.CombatTypeArgument.None;
+            newprotocol.ForwardType = handler_ForwardType.GetNewShiftToOldJitInstance();
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         public override byte[] NewShiftToOld(byte[] arr, int offset, int length)

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerCombatInvokeEntry.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerCombatInvokeEntry.cs
@@ -196,21 +196,61 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.ForwardType = handler_ForwardType.GetNewShiftToOldJitInstance();
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override byte[] NewShiftToOld(byte[] arr, int offset, int length)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length)).ToByteArray();
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(span)).ToByteArray();
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length));
+            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
+            return rtn;
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override ByteString NewShiftToOld(ByteString bytes)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(bytes)).ToByteString();
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(bytes));
+            return rtn == null ? ByteString.Empty : rtn.ToByteString();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override byte[] OldShiftToNew(byte[] arr, int offset, int length)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length)).ToByteArray();
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(span)).ToByteArray();
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length));
+            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
+            return rtn;
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override ByteString OldShiftToNew(ByteString bytes)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(bytes)).ToByteString();
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(bytes));
+            return rtn == null ? ByteString.Empty : rtn.ToByteString();
+        }
 
         private static HandlerCombatInvokeEntry _globalOnlyInstance = new HandlerCombatInvokeEntry();
         public static HandlerCombatInvokeEntry GlobalInstance => _globalOnlyInstance;

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGAttackCostInfo.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGAttackCostInfo.cs
@@ -40,6 +40,18 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             handler_fuck.OldShiftToNew(oldprotocol.CostMap, newprotocol.CostList);
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
+        public override NewProtos.GCGAttackCostInfo GetNewShiftToOldJitInstance()
+        {
+            NewProtos.GCGAttackCostInfo newprotocol = new();
+            newprotocol.CostList.Add(handler_fuck.GetNewShiftToOldJitInstance());
+            newprotocol.SkillId = 20231024;
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         [System.Diagnostics.DebuggerNonUserCode]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGAttackCostInfo.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGAttackCostInfo.cs
@@ -51,6 +51,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.SkillId = 20231024;
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -63,10 +73,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
@@ -84,10 +94,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgPhaseChange.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgPhaseChange.cs
@@ -43,6 +43,19 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             handler_fuck.OldShiftToNew(oldprotocol.AllowControllerMap, newprotocol.AllowControllerList);
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
+        public override NewProtos.GCGMsgPhaseChange GetNewShiftToOldJitInstance()
+        {
+            NewProtos.GCGMsgPhaseChange newprotocol = new();
+            newprotocol.AfterPhase = handler_GCGPhaseType.GetNewShiftToOldJitInstance();
+            newprotocol.AllowControllerList.Add(handler_fuck.GetNewShiftToOldJitInstance());
+            newprotocol.BeforePhase = handler_GCGPhaseType.GetNewShiftToOldJitInstance();
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         [System.Diagnostics.DebuggerNonUserCode]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgPhaseChange.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgPhaseChange.cs
@@ -55,6 +55,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.BeforePhase = handler_GCGPhaseType.GetNewShiftToOldJitInstance();
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -67,10 +77,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
@@ -88,10 +98,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgUpdateController.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgUpdateController.cs
@@ -38,6 +38,15 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             handler_fuck.OldShiftToNew(oldprotocol.AllowControllerMap, newprotocol.AllowControllerList);
             return newprotocol;
         }
+
+        #region JIT API
+        public override NewProtos.GCGMsgUpdateController GetNewShiftToOldJitInstance()
+        {
+            NewProtos.GCGMsgUpdateController newprotocol = new();
+            newprotocol.AllowControllerList.Add(handler_fuck.GetNewShiftToOldJitInstance());
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         [System.Diagnostics.DebuggerNonUserCode]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgUpdateController.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGMsgUpdateController.cs
@@ -46,6 +46,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.AllowControllerList.Add(handler_fuck.GetNewShiftToOldJitInstance());
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -58,10 +68,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
@@ -79,10 +89,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGPlayCardCostInfo.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGPlayCardCostInfo.cs
@@ -51,6 +51,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.CostList.Add(handler_fuck.GetNewShiftToOldJitInstance());
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -63,10 +73,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
@@ -84,10 +94,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGPlayCardCostInfo.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGPlayCardCostInfo.cs
@@ -40,6 +40,18 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             handler_fuck.OldShiftToNew(oldprotocol.CostMap, newprotocol.CostList);
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
+        public override NewProtos.GCGPlayCardCostInfo GetNewShiftToOldJitInstance()
+        {
+            NewProtos.GCGPlayCardCostInfo newprotocol = new();
+            newprotocol.CardId = 20231024;
+            newprotocol.CostList.Add(handler_fuck.GetNewShiftToOldJitInstance());
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         [System.Diagnostics.DebuggerNonUserCode]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGSelectOnStageCostInfo.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGSelectOnStageCostInfo.cs
@@ -51,6 +51,16 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             newprotocol.CostList.Add(handler_fuck.GetNewShiftToOldJitInstance());
             return newprotocol;
         }
+            
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override void RunJit()
+        {
+            var instance = GetNewShiftToOldJitInstance();
+            OldShiftToNew(NewShiftToOld(instance.ToByteArray()));
+            OldShiftToNew(new Span<byte>(NewShiftToOld(new Span<byte>(instance.ToByteArray())).ToByteArray()));
+            OldShiftToNew(NewShiftToOld(instance.ToByteString()));
+        }
         #endregion
         #endregion
 
@@ -63,10 +73,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
         {
             var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
@@ -84,10 +94,10 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
         {
             var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
-            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+            return rtn;
         }
         [System.Diagnostics.DebuggerNonUserCode]
         [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerGCGSelectOnStageCostInfo.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerGCGSelectOnStageCostInfo.cs
@@ -40,6 +40,18 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             handler_fuck.OldShiftToNew(oldprotocol.CostMap, newprotocol.CostList);
             return newprotocol;
         }
+
+        #region JIT API
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.1.0")]
+        public override NewProtos.GCGSelectOnStageCostInfo GetNewShiftToOldJitInstance()
+        {
+            NewProtos.GCGSelectOnStageCostInfo newprotocol = new();
+            newprotocol.CardGuid = 20231024;
+            newprotocol.CostList.Add(handler_fuck.GetNewShiftToOldJitInstance());
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         [System.Diagnostics.DebuggerNonUserCode]

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerUnionCmd.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerUnionCmd.cs
@@ -65,6 +65,15 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
             }
             return newprotocol;
         }
+
+        #region JIT API
+        public override NewProtos.UnionCmd GetNewShiftToOldJitInstance()
+        {
+            NewProtos.UnionCmd newprotocol = new();
+            newprotocol.MessageId = 0;
+            return newprotocol;
+        }
+        #endregion
         #endregion
 
         public override byte[] NewShiftToOld(byte[] arr, int offset, int length)

--- a/ProtoshiftHandlers/SpecialHandlers/HandlerUnionCmd.cs
+++ b/ProtoshiftHandlers/SpecialHandlers/HandlerUnionCmd.cs
@@ -27,7 +27,7 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
                         newprotocol.MessageId, null, newprotocol.Body);
                 }
             }
-            catch (NotSupportedException ex)
+            catch (NotSupportedException)
             {
                 Log.Warn($"HandlerUnionCmd meets error so dropped a packet: Cmd {newprotocol.MessageId} (new) not supported.", nameof(HandlerUnionCmd));
                 return new OldProtos.UnionCmd();
@@ -76,18 +76,48 @@ namespace csharp_Protoshift.Enhanced.Handlers.GeneratedCode
         #endregion
         #endregion
 
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override byte[] NewShiftToOld(byte[] arr, int offset, int length)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length)).ToByteArray();
-        public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(span)).ToByteArray();
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(arr, offset, length));
+            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
+            return rtn;
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override ByteString NewShiftToOld(ByteString bytes)
-            => NewShiftToOld(newproto_parser_base.ParseFrom(bytes)).ToByteString();
+        {
+            var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(bytes));
+            return rtn == null ? ByteString.Empty : rtn.ToByteString();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override byte[] OldShiftToNew(byte[] arr, int offset, int length)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length)).ToByteArray();
-        public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(span)).ToByteArray();
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(arr, offset, length));
+            return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
+        public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
+            return rtn;
+        }
+        [System.Diagnostics.DebuggerNonUserCode]
+        [System.CodeDom.Compiler.GeneratedCode("YYHEggEgg/csharp_Protoshift.HandlerGenerator", "1.0.0.0")]
         public override ByteString OldShiftToNew(ByteString bytes)
-            => OldShiftToNew(oldproto_parser_base.ParseFrom(bytes)).ToByteString();
+        {
+            var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(bytes));
+            return rtn == null ? ByteString.Empty : rtn.ToByteString();
+        }
 
         private static HandlerUnionCmd _globalOnlyInstance = new HandlerUnionCmd();
         public static HandlerUnionCmd GlobalInstance => _globalOnlyInstance;

--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ csharp-Protoshift is an advanced, manageable compatibility layer for a certain a
 
 - Protobuf / `query_cur_region` / Ec2b and other utility commands.
 
-## Update
+## Update - v1.0.2
 
 - Support initiated JIT compiling for Protoshift Handlers. For information, please view [PR #36](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36).
+- 修复了 `HandlerGenerator` 由于 Git `safe.directory` 配置而在某些环境下无法完成 Protos 抓取与还原的问题。
+- 修复了 `HandlerGenerator` 在工程目录中存在空格的情况下无法完成 Protos 抓取与还原的问题。
+- 修复了 `csharp-Protoshift` 在工程目录中存在空格的情况下无法调用 `luac` 编译 Windy lua 脚本的问题。
 - Fixed the issue where `csharp-Protoshift-Replay` could not start due to the inability to find the resource folder.
 - Fixed the problem where the command line option `--orderby-packet-speed` of `ProtoshiftBenchmark` did not actually take effect.
 - Added support for proactive JIT compilation to `csharp-Protoshift-Replay`.
@@ -57,7 +60,7 @@ In addition, I strongly recommend that you:
 - Ensure **stable** access to GitHub when running the build (`./update`).
 - Use VS Code for path shortcut jumps, JSON Schema support, etc.
 
-If for some reason you cannot add the above software to the system environment variables, you can instruct the program to call their absolute paths. For details on this special configuration, please refer to the [Wiki - Building - Prerequisites](https://github.com/YYHEggEgg/csharp-Protoshift/wiki/EN_Building#prerequisites) guide.
+If for some reason you cannot add the above software to the system environment variables, you can instruct the program to call their absolute paths. For details on this special configuration, please refer to the [Wiki - Building - Prerequisite Environment Requirements](https://github.com/YYHEggEgg/csharp-Protoshift/wiki/EN_Building#prerequisite-environment-requirements) guide.
 
 ### Build and Run
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ csharp-Protoshift is an advanced, manageable compatibility layer for a certain a
 ## Update - v1.0.2
 
 - Support initiated JIT compiling for Protoshift Handlers. For information, please view [PR #36](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36).
-- 修复了 `HandlerGenerator` 由于 Git `safe.directory` 配置而在某些环境下无法完成 Protos 抓取与还原的问题。
-- 修复了 `HandlerGenerator` 在工程目录中存在空格的情况下无法完成 Protos 抓取与还原的问题。
-- 修复了 `csharp-Protoshift` 在工程目录中存在空格的情况下无法调用 `luac` 编译 Windy lua 脚本的问题。
+- Fixed the issue whereby `HandlerGenerator` being unable to fetch and restore Protos due to the Git `safe.directory` configuration in certain environments.
+- Fixed the issue whereby `HandlerGenerator` being unable to fetch and restore Protos when there are spaces in the project directory.
+- Fixed the issue whereby `csharp-Protoshift` being unable to invoke `luac` to compile Windy lua scripts when there are spaces in the project directory.
+- Fixed the issue whereby `HandlerGenerator` displaying abnormal exit prompt text when the external application invocation fails.
+- Fixed the issue whereby `HandlerGenerator` being unable to correctly invoke Powershell in Windows to execute post-generation scripts when there are spaces in the project directory.
 - Fixed the issue where `csharp-Protoshift-Replay` could not start due to the inability to find the resource folder.
 - Fixed the problem where the command line option `--orderby-packet-speed` of `ProtoshiftBenchmark` did not actually take effect.
 - Added support for proactive JIT compilation to `csharp-Protoshift-Replay`.
@@ -69,6 +71,7 @@ Once the prerequisites are met, just run the following commands:
 ```sh
 git clone --branch main https://github.com/YYHEggEgg/csharp-Protoshift
 cd csharp-Protoshift
+git submodule update --init --recursive
 ./update
 ```
 
@@ -99,6 +102,8 @@ Finally, run the following command to start the server immediately:
 ```
 
 You can also use `./run` to start the Protoshift server at any time, and use `./update` to get updates. Of course, if you want to run in Release mode (for higher performance), you can use `./scripts/run-rel`.
+
+Additionally, Protoshift does not take effect automatically on the client side; it acts as a reverse proxy, so you need to have them connect to the port opened by Protoshift server. If you are unsure how to do this, please contact your SDK server developer.
 
 ## More Usage
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ csharp-Protoshift is an advanced, manageable compatibility layer for a certain a
 
 - Protobuf / `query_cur_region` / Ec2b and other utility commands.
 
+## Update
+
+- Support initiated JIT compiling for Protoshift Handlers. For information, please view [PR #36](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36).
+- Fixed the issue where `csharp-Protoshift-Replay` could not start due to the inability to find the resource folder.
+- Fixed the problem where the command line option `--orderby-packet-speed` of `ProtoshiftBenchmark` did not actually take effect.
+- Added support for proactive JIT compilation to `csharp-Protoshift-Replay`.
+- Fixed the issue where `ProtoshiftBenchmark` and `csharp-Protoshift-Replay` prompted error due to syntax errors during compilation.
+- Added `-f, --source-file` and `--fully-replay-packet-time` command line options to `csharp-Protoshift-Replay`.
+- Fixed the running issues of the "run-benchmark" series scripts.
+
 ## Quick Installation Guide
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ csharp-Protoshift is an advanced, manageable compatibility layer for a certain a
 - Fixed the issue where `ProtoshiftBenchmark` and `csharp-Protoshift-Replay` prompted error due to syntax errors during compilation.
 - Added `-f, --source-file` and `--fully-replay-packet-time` command line options to `csharp-Protoshift-Replay`.
 - Fixed the running issues of the "run-benchmark" series scripts.
+- Added more built-in scripts. For more information, please refer to [Wiki - Development - Built-in Scripts](https://github.com/YYHEggEgg/csharp-Protoshift/wiki/WN_Development#built-in-scripts).
 
 ## Quick Installation Guide
 

--- a/Tests/KcpTests/KcpPerformanceTest/KcpPerformanceTest.csproj
+++ b/Tests/KcpTests/KcpPerformanceTest/KcpPerformanceTest.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="EPPlus" Version="6.2.7" />
     <PackageReference Include="Google.Protobuf" Version="3.23.4" />
   </ItemGroup>

--- a/Tests/KcpTests/SharedLib/SharedLib.csproj
+++ b/Tests/KcpTests/SharedLib/SharedLib.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.23.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/Tests/ProtoshiftBenchmark/Program.cs
+++ b/Tests/ProtoshiftBenchmark/Program.cs
@@ -52,7 +52,16 @@ namespace csharp_Protoshift.Enhanced.Benchmark
             if (sourcefile == null)
             {
                 Log.Info("Please drag in the latest.packet.log file:");
-                sourcefile = Console.ReadLine();
+                try
+                {
+                    sourcefile = Console.ReadLine();
+                }
+                catch (Exception ex)
+                {
+                    Log.Erro(ex.ToString());
+                    Log.Erro($"Please provide a valid file!");
+                    Environment.Exit(1);
+                }
             }
             if (sourcefile == null) throw new Exception("im tired plz give a file ok?");
             SetUpBenchmarkSource(sourcefile, global_opt);

--- a/Tests/ProtoshiftBenchmark/Program.cs
+++ b/Tests/ProtoshiftBenchmark/Program.cs
@@ -54,10 +54,11 @@ namespace csharp_Protoshift.Enhanced.Benchmark
                 Log.Info("Please drag in the latest.packet.log file:");
                 sourcefile = Console.ReadLine();
             }
-            if (sourcefile == null) throw new Exception("im tired plz give a file ok?");
+            if (string.IsNullOrEmpty(sourcefile)) throw new Exception("im tired plz give a file ok?");
             if (!File.Exists(sourcefile))
             {
                 Log.Erro($"Please provide a valid file! Program read: '{sourcefile}'");
+                Environment.Exit(1);
             }
             SetUpBenchmarkSource(sourcefile, global_opt);
 

--- a/Tests/ProtoshiftBenchmark/Program.cs
+++ b/Tests/ProtoshiftBenchmark/Program.cs
@@ -52,18 +52,13 @@ namespace csharp_Protoshift.Enhanced.Benchmark
             if (sourcefile == null)
             {
                 Log.Info("Please drag in the latest.packet.log file:");
-                try
-                {
-                    sourcefile = Console.ReadLine();
-                }
-                catch (Exception ex)
-                {
-                    Log.Erro(ex.ToString());
-                    Log.Erro($"Please provide a valid file!");
-                    Environment.Exit(1);
-                }
+                sourcefile = Console.ReadLine();
             }
             if (sourcefile == null) throw new Exception("im tired plz give a file ok?");
+            if (!File.Exists(sourcefile))
+            {
+                Log.Erro($"Please provide a valid file! Program read: '{sourcefile}'");
+            }
             SetUpBenchmarkSource(sourcefile, global_opt);
 
             // Set up and test-run

--- a/Tests/ProtoshiftBenchmark/Program.cs
+++ b/Tests/ProtoshiftBenchmark/Program.cs
@@ -21,6 +21,19 @@ namespace csharp_Protoshift.Enhanced.Benchmark
 
         private static void Main(string[] args)
         {
+            var parser_args = Parser.Default;
+            //new Parser(config =>
+            // {
+                // Set custom ConsoleWriter during construction
+            //     config.HelpWriter = TextWriter.Synchronized(new LogTextWriter("CommandLineParser"));
+            // });
+            BenchmarkOptions global_opt = new BenchmarkOptions();
+            parser_args.ParseArguments<BenchmarkOptions>(args)
+                .WithNotParsed(errs =>
+                {
+                    Environment.Exit(1);
+                })
+                .WithParsed(o => global_opt = o);
             StartupWorkingDirChanger.ChangeToDotNetRunPath(new LoggerConfig(
                 max_Output_Char_Count: 16 * 1024,
                 use_Console_Wrapper: false,
@@ -34,20 +47,6 @@ namespace csharp_Protoshift.Enhanced.Benchmark
                 File.Move(benchmark_source_file_shared,
                     $"logs/{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.{benchmark_source_file_suffix}");
             }
-            var parser_args = Parser.Default;
-            //new Parser(config =>
-            // {
-                // Set custom ConsoleWriter during construction
-            //     config.HelpWriter = TextWriter.Synchronized(new LogTextWriter("CommandLineParser"));
-            // });
-            BenchmarkOptions global_opt = new BenchmarkOptions();
-            parser_args.ParseArguments<BenchmarkOptions>(args)
-                .WithNotParsed(errs =>
-                {
-                    Log.Erro("Unrecognized args detected. Please check your input.");
-                    Environment.Exit(0);
-                })
-                .WithParsed(o => global_opt = o);
 
             string? sourcefile = global_opt.FilePath;
             if (sourcefile == null)

--- a/Tests/ProtoshiftBenchmark/Program.cs
+++ b/Tests/ProtoshiftBenchmark/Program.cs
@@ -162,13 +162,24 @@ namespace csharp_Protoshift.Enhanced.Benchmark
             HashSet<string> proto_filters = new(opt.ProtoFilters ?? Enumerable.Empty<string>());
             IEnumerable<IGrouping<string, (string protoname, ushort cmdid, bool sentByClient, byte[] body, int line_id, Int64 handlenanosec)>> select_res;
 
-            select_res = 
-                from record in readres
-                orderby (opt.OrderByPacketTime ? record.handlenanosec : record.body.Length) descending
-                orderby record.body.Length descending
-                group record by record.protoname into gr
-                where opt.ProtoFilters == null || proto_filters.Contains(gr.Key)
-                select gr;
+            if (opt.OrderByPacketTime)
+            {
+                select_res =
+                    from record in readres
+                    orderby record.handlenanosec descending
+                    group record by record.protoname into gr
+                    where opt.ProtoFilters == null || proto_filters.Contains(gr.Key)
+                    select gr;
+            }
+            else
+            {
+                select_res =
+                    from record in readres
+                    orderby record.body.Length descending
+                    group record by record.protoname into gr
+                    where opt.ProtoFilters == null || proto_filters.Contains(gr.Key)
+                    select gr;
+            }
             StringBuilder sb = new();
             foreach (var proto_gr in select_res)
             {

--- a/Tests/ProtoshiftBenchmark/ProtoshiftBenchmark.csproj
+++ b/Tests/ProtoshiftBenchmark/ProtoshiftBenchmark.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
   </ItemGroup>
 

--- a/Tests/csharp-Protoshift-Replay/GameSession/PacketRecordCollection.cs
+++ b/Tests/csharp-Protoshift-Replay/GameSession/PacketRecordCollection.cs
@@ -69,7 +69,7 @@ namespace csharp_Protoshift.Debug.Replay
                 }
                 // See Remarks of
                 // https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.delay?view=net-7.0#system-threading-tasks-task-delay(system-timespan)
-                if (replay.offset > TimeSpan.FromMilliseconds(15))
+                if (replay.offset > TimeSpan.FromMilliseconds(15) && !Program.FullyReplayPacketTime)
                     await Task.Delay(replay.offset);
                 try
                 {

--- a/Tests/csharp-Protoshift-Replay/csharp-Protoshift-Replay.csproj
+++ b/Tests/csharp-Protoshift-Replay/csharp-Protoshift-Replay.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="EPPlus" Version="6.2.9" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
   </ItemGroup>

--- a/Tests/csharp-Protoshift-Replay/csharp-Protoshift-Replay.csproj
+++ b/Tests/csharp-Protoshift-Replay/csharp-Protoshift-Replay.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
     <PackageReference Include="EPPlus" Version="6.2.9" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />

--- a/Tests/run-benchmark.ps1
+++ b/Tests/run-benchmark.ps1
@@ -1,3 +1,16 @@
 cd ProtoshiftBenchmark
-dotnet run --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
-cd ..
+dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
+$build_exitcode = $LastExitCode
+if ($build_exitcode -eq 0)
+{
+    Write-Host MSBuild finished. Running...
+    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
+    cd ..
+    exit $LastExitCode
+}
+else
+{
+    Write-Host MSBuild failed with exitcode $build_exitcode.
+    cd ..
+    exit $build_exitcode
+}

--- a/Tests/run-benchmark.sh
+++ b/Tests/run-benchmark.sh
@@ -5,7 +5,7 @@ dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...
-    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
+    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $@
     exit $?
 else
     echo MSBuild failed with exitcode $build_exitcode.

--- a/csharp-Protoshift/Commands/Windy/WindyCompilerManager.cs
+++ b/csharp-Protoshift/Commands/Windy/WindyCompilerManager.cs
@@ -4,6 +4,7 @@ using csharp_Protoshift.Configuration;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 using System.Diagnostics.CodeAnalysis;
+using csharp_Protoshift.resLoader;
 
 namespace csharp_Protoshift.Commands.Windy
 {
@@ -25,17 +26,17 @@ namespace csharp_Protoshift.Commands.Windy
             _logger = Log.GetChannel("WindyCompilers");
             LuaCompilersDefault = new(new Dictionary<OSType, string>
             {
-                { OSType.win32, "resources/luac_bins/luac_win32.exe" },
-                { OSType.win64, "resources/luac_bins/luac_win64.exe" },
-                // { OSType.mac32, "resources/luac_bins/luac_mac32" },
-                { OSType.mac64, "resources/luac_bins/luac_unix64" },
-                // { OSType.linux32, "resources/luac_bins/luac_linux32" },
-                { OSType.linux64, "resources/luac_bins/luac_unix64" },
+                { OSType.win32, Path.Combine(Resources.BasePath, "luac_bins/luac_win32.exe") },
+                { OSType.win64, Path.Combine(Resources.BasePath, "luac_bins/luac_win64.exe") },
+                // { OSType.mac32, Path.Combine(Resources.BasePath, "luac_bins/luac_mac32") },
+                { OSType.mac64, Path.Combine(Resources.BasePath, "luac_bins/luac_unix64") },
+                // { OSType.linux32, Path.Combine(Resources.BasePath, "luac_bins/luac_linux32") },
+                { OSType.linux64, Path.Combine(Resources.BasePath, "luac_bins/luac_unix64") },
             });
             ChmodAddX();
             _lua_compilers_path = new(LuaCompilersDefault);
 
-            Directory.Delete("windy_temp", true);
+            try { Directory.Delete("windy_temp", true); } catch {  }
             var settmpPathRes = SetCompiledTempPath("windy_temp");
             Debug.Assert(settmpPathRes);
         }

--- a/csharp-Protoshift/Commands/Windy/WindyLuacManager.cs
+++ b/csharp-Protoshift/Commands/Windy/WindyLuacManager.cs
@@ -254,8 +254,8 @@ and don't place your files here as they will probably be lost.";
             string res = string.Empty;
             if (Config.Global.WindyConfig.StripDebugInformation == true)
                 res += "-s ";
-            res += $"-o {outputPath} ";
-            res += fileSource.FullName;
+            res += $"-o \"{outputPath}\" ";
+            res += $"\"{fileSource.FullName}\"";
             return res;
         }
     }

--- a/csharp-Protoshift/Commands/Windy/WindyLuacManager.cs
+++ b/csharp-Protoshift/Commands/Windy/WindyLuacManager.cs
@@ -1,4 +1,5 @@
 ﻿using csharp_Protoshift.Configuration;
+using csharp_Protoshift.resLoader;
 using Google.Protobuf;
 using System.Diagnostics;
 using System.Text.Json;
@@ -76,7 +77,7 @@ namespace csharp_Protoshift.Commands.Windy
         #endregion
 
         #region EnvPath
-        private static string _envPath = "resources/windy_scripts";
+        private static string _envPath = Path.Combine(Resources.BasePath, "windy_scripts");
         /// <summary>
         /// Get the windy env path. 
         /// </summary>

--- a/csharp-Protoshift/Config/Config.cs
+++ b/csharp-Protoshift/Config/Config.cs
@@ -1,4 +1,5 @@
 using csharp_Protoshift.Commands.Windy;
+using csharp_Protoshift.resLoader;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NJsonSchema;
@@ -51,7 +52,8 @@ namespace csharp_Protoshift.Configuration
                 return null;
             }
             var schema_cur_version = await JsonSchema.FromJsonAsync(
-                await File.ReadAllTextAsync($"resources/config-schemas/config_schema_v{configVersion}.json"));
+                await File.ReadAllTextAsync(Path.Combine(
+                    Resources.BasePath, $"config-schemas/config_schema_v{configVersion}.json")));
             Debug.Assert(schema_cur_version != null);
             schema_cur_version.AllowAdditionalItems = true;
             schema_cur_version.AllowAdditionalProperties = true;

--- a/csharp-Protoshift/Config/Config_v1.0.1.cs
+++ b/csharp-Protoshift/Config/Config_v1.0.1.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using csharp_Protoshift.resLoader;
+using Newtonsoft.Json;
 using YYHEggEgg.Logger;
 
 #pragma warning disable CS8618 // 在退出构造函数时，不可为 null 的字段必须包含非 null 值。请考虑声明为可以为 null。
@@ -83,7 +84,7 @@ namespace csharp_Protoshift.Configuration
                 rtn.WindyConfig = new WindyConfig_v1_0_1
                 {
                     WindyCompiledTempPath = olderwindyconf.WindyCompiledTempPath ?? "windy_temp",
-                    WindyEnvironmentPath = olderwindyconf.WindyEnvironmentPath ?? "resources/windy_scripts",
+                    WindyEnvironmentPath = olderwindyconf.WindyEnvironmentPath ?? Path.Combine(Resources.BasePath, "windy_scripts"),
                 };
                 if (olderwindyconf.OnlineExecWindyLua != null)
                 {

--- a/csharp-Protoshift/GameSession/GameSessionDispatch.cs
+++ b/csharp-Protoshift/GameSession/GameSessionDispatch.cs
@@ -263,6 +263,11 @@ namespace csharp_Protoshift.GameSession
         }
 #endif
 
+        /// <summary>
+        /// Invoke the static initializer and create latest.packet.log and latest.player.stat.log.
+        /// </summary>
+        public static void InitializeLogFiles() {  }
+
         private static void AssertSessionExists(uint conv)
         {
             if (Closed) throw new OperationCanceledException("The server is closing.");

--- a/csharp-Protoshift/GameSession/HandlerSession.Common.cs
+++ b/csharp-Protoshift/GameSession/HandlerSession.Common.cs
@@ -37,7 +37,7 @@ namespace csharp_Protoshift.GameSession
         public HandlerSession(uint sessionId)
         {
             _xorKey = Resources.dispatchKey;
-            Debug.Assert(_xorKey.Length == 4096);
+            // Debug.Assert(_xorKey.Length == 4096);
             _sessionId = sessionId;
             client_seed = server_seed = Array.Empty<byte>();
             // Verbose = true;

--- a/csharp-Protoshift/KCP/KcpProxy/KcpProxyBase.cs
+++ b/csharp-Protoshift/KCP/KcpProxy/KcpProxyBase.cs
@@ -16,7 +16,7 @@ namespace csharp_Protoshift.MhyKCP.Proxy
     {
         public KcpProxyClient? sendClient;
         public EndPoint sendToAddress;
-        protected static LoggerChannel? _kcpstatlogchan = GameSessionDispatch.PlayerStatLogger?.GetChannel(null);
+        protected static LoggerChannel? _kcpstatlogchan = KcpProxyServer._kcpstatlogger?.GetChannel(null);
 
         private object handshake_lock = "Tighnari beloved";
 
@@ -116,7 +116,8 @@ namespace csharp_Protoshift.MhyKCP.Proxy
                             sendClient.ConnectAsync().Wait(); 
 
                             var sendBackConv = sendClient.GetSendbackHandshake();
-                            _kcpstatlogchan = GameSessionDispatch.PlayerStatLogger?.GetChannel(sendBackConv.Conv.ToString());
+                            if (_kcpstatlogchan != null)
+                                _kcpstatlogchan.LogSender = sendBackConv.Conv.ToString();
                             sendClient.StartDisconnected += (conv, token, data) =>
                             {
                                 Log.Info($"Server (conv: {_Conv}) requested to disconnect (reason: {data}), so send disconnect to client", nameof(KcpProxyBase));

--- a/csharp-Protoshift/KCP/KcpProxy/KcpProxyServer.cs
+++ b/csharp-Protoshift/KCP/KcpProxy/KcpProxyServer.cs
@@ -12,7 +12,25 @@ namespace csharp_Protoshift.MhyKCP.Proxy
     public class KcpProxyServer : KCPServer
     {
         public EndPoint SendToEndpoint { get; }
-        protected static BaseLogger? _kcpstatlogger = GameSessionDispatch.PlayerStatLogger;
+        internal static BaseLogger? _kcpstatlogger;
+
+#if !PROTOSHIFT_BENCHMARK
+        static KcpProxyServer()
+        {
+            _kcpstatlogger = new BaseLogger(new LoggerConfig(
+                max_Output_Char_Count: 16 * 1024,
+                use_Console_Wrapper: true,
+                use_Working_Directory: true,
+#if DEBUG
+                global_Minimum_LogLevel: LogLevel.Debug,
+#else
+                global_Minimum_LogLevel: LogLevel.Information,
+#endif
+                console_Minimum_LogLevel: LogLevel.None,
+                debug_LogWriter_AutoFlush: false,
+                enable_Detailed_Time: true), "player.stat");
+        }
+#endif
 
         public KcpProxyServer(IPEndPoint bindToAddress, EndPoint sendToAddress)
         {

--- a/csharp-Protoshift/Program.cs
+++ b/csharp-Protoshift/Program.cs
@@ -109,6 +109,7 @@ namespace csharp_Protoshift
                     Config.Global.NetConfig.BindPort);
                 var remoteIp = new IPEndPoint(remoteaddr, Config.Global.NetConfig.RemoteAddress.AddressPort);
 
+                GameSessionDispatch.InitializeLogFiles();
                 ProxyServer = new KcpProxyServer(bindIp, remoteIp);
 
                 ProxyHandlers handlers = new ProxyHandlers

--- a/csharp-Protoshift/Program.cs
+++ b/csharp-Protoshift/Program.cs
@@ -126,6 +126,21 @@ namespace csharp_Protoshift
                     Log.Info(OldProtos.QueryJsonSerializer.Initialize(), "OldProtos_AsyncLoad");
                     Log.Info(NewProtos.QueryJsonSerializer.Initialize(), "NewProtos_AsyncLoad");
                 });
+                _ = Task.Run(() =>
+                {
+                    var log = Log.GetChannel($"{nameof(ProtoshiftDispatch.RunHandlersJit)}_AsyncTask");
+                    log.LogInfo($"Start running initiated Protoshift Handlers JIT in Background..");
+                    try
+                    {
+                        ProtoshiftDispatch.RunHandlersJit();
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogErroTrace(ex, "Protoshift Handlers JIT failed. " +
+                            "Please check your custom Handlers (ProtoshiftHandlers/SpecialHandlers) " +
+                            "or open an issue related to this in our repository.");
+                    }
+                });
                 Log.Info($"Protoshift server started on {bindIp}, real server at {remoteIp}.", "Entry");
                 Log.Info("Ready! Type 'help' to get command help.", "Entry");
             }

--- a/csharp-Protoshift/csharp-Protoshift.csproj
+++ b/csharp-Protoshift/csharp-Protoshift.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>csharp_Protoshift</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>YYHEggEgg</Authors>
     <Copyright>Copyright (c) 2023 EggEgg</Copyright>
   </PropertyGroup>

--- a/csharp-Protoshift/csharp-Protoshift.csproj
+++ b/csharp-Protoshift/csharp-Protoshift.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.0" />
+    <PackageReference Include="EggEgg.CSharp-Logger" Version="4.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />

--- a/csharp-Protoshift/resLoader/Resources.cs
+++ b/csharp-Protoshift/resLoader/Resources.cs
@@ -4,6 +4,11 @@ namespace csharp_Protoshift.resLoader
 {
     public static class Resources
     {
+        /// <summary>
+        /// The path provided in the successful attempt of <see cref="ResourcesLoader.Load(string)"/>.
+        /// </summary>
+        public static string BasePath = "./resources";
+
         public static byte[] dispatchKey = new byte[] { };
         public static byte[] dispatchSeed = new byte[] { };
         public static Dictionary<uint, RSAUtilBase> CPri = new();

--- a/csharp-Protoshift/resLoader/ResourcesLoader.cs
+++ b/csharp-Protoshift/resLoader/ResourcesLoader.cs
@@ -208,6 +208,8 @@ namespace csharp_Protoshift.resLoader
                 }
             }
             #endregion
+        
+            Resources.BasePath = resPath;
         }
         
         

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -40,6 +40,7 @@ csharp-Protoshift 可为某二游提供先进、易管理的兼容性扩展。
 - 修复了 `ProtoshiftBenchmark` 和 `csharp-Protoshift-Replay` 提示因语法错误无法编译的问题。
 - 为 `csharp-Protoshift-Replay` 添加了 `-f, --source-file` 与 `--fully-replay-packet-time` 命令行选项。
 - 修复了 `run-benchmark` 系列脚本的运行问题。
+- 添加了更多快捷脚本。有关详细信息，请参阅 [Wiki - Development - 内置脚本](https://github.com/YYHEggEgg/csharp-Protoshift/wiki/CN_Development#内置脚本)。
 
 ## 快速安装指南
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -73,6 +73,7 @@ csharp-Protoshift 可为某二游提供先进、易管理的兼容性扩展。
 ```sh
 git clone --branch main https://github.com/YYHEggEgg/csharp-Protoshift
 cd csharp-Protoshift
+git submodule update --init --recursive
 ./update
 ```
 
@@ -103,6 +104,8 @@ cd csharp-Protoshift
 ```
 
 您以后也可以随时使用 `./run` 启动 Protoshift 服务器，使用 `./update` 来获取更新。当然如果您想要以 Release 运行（可达到更高的性能），可以使用 `./scripts/run-rel`.
+
+另外，Protoshift 并不能自动对客户端生效；它类似一个反向代理，因此您必须使他们连接至 Protoshift 服务器开放的端口。如果您不知道如何做到这一点，请与您的 SDK 服务器开发者联系。
 
 ## 更多用法
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -34,6 +34,11 @@ csharp-Protoshift 可为某二游提供先进、易管理的兼容性扩展。
 ### v1.0.2
 
 - 支持对于 Protoshift Handlers 主动进行提前 JIT 编译。有关详细信息，请参阅 [PR #36](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36).
+- 修复了 `HandlerGenerator` 由于 Git `safe.directory` 配置而在某些环境下无法完成 Protos 抓取与还原的问题。
+- 修复了 `HandlerGenerator` 在工程目录中存在空格的情况下无法完成 Protos 抓取与还原的问题。
+- 修复了 `csharp-Protoshift` 在工程目录中存在空格的情况下无法调用 `luac` 编译 Windy lua 脚本的问题。
+- 修复了 `HandlerGenerator` 调用外部应用失败时退出提示文本异常的问题。
+- 修复了 `HandlerGenerator` 在工程目录中存在空格的情况下无法正确调用 Windows 下的 Powershell 执行生成后任务脚本的问题。
 - 修复了 `csharp-Protoshift-Replay` 因无法找到资源文件夹而无法启动的问题。
 - 修复了 `ProtoshiftBenchmark` 的命令行选项 `--orderby-packet-speed` 实际未生效的问题。
 - 为 `csharp-Protoshift-Replay` 添加了主动 JIT 编译支持。

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -29,6 +29,18 @@ csharp-Protoshift 可为某二游提供先进、易管理的兼容性扩展。
 
 - Protobuf / `query_cur_region` / Ec2b 等工具命令。
 
+## 更新
+
+### v1.0.2
+
+- 支持对于 Protoshift Handlers 主动进行提前 JIT 编译。有关详细信息，请参阅 [PR #36](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36).
+- 修复了 `csharp-Protoshift-Replay` 因无法找到资源文件夹而无法启动的问题。
+- 修复了 `ProtoshiftBenchmark` 的命令行选项 `--orderby-packet-speed` 实际未生效的问题。
+- 为 `csharp-Protoshift-Replay` 添加了主动 JIT 编译支持。
+- 修复了 `ProtoshiftBenchmark` 和 `csharp-Protoshift-Replay` 提示因语法错误无法编译的问题。
+- 为 `csharp-Protoshift-Replay` 添加了 `-f, --source-file` 与 `--fully-replay-packet-time` 命令行选项。
+- 修复了 `run-benchmark` 系列脚本的运行问题。
+
 ## 快速安装指南
 
 ### 前置环境需求

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd HandlerGenerator
-dotnet build
+dotnet build --configuration Release
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -1,5 +1,5 @@
 cd HandlerGenerator
-dotnet build
+dotnet build --configuration Release
 $build_exitcode = $LastExitCode
 if ($build_exitcode -eq 0)
 {

--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd HandlerGenerator
+dotnet build
+build_exitcode=$?
+if [ $build_exitcode == 0 ]; then
+    echo MSBuild finished. Running...
+    dotnet run --no-build -- --update $@
+    exit $?
+else
+    echo MSBuild failed with exitcode $build_exitcode.
+    exit $build_exitcode
+fi

--- a/scripts/rebuild.ps1
+++ b/scripts/rebuild.ps1
@@ -1,0 +1,16 @@
+cd HandlerGenerator
+dotnet build
+$build_exitcode = $LastExitCode
+if ($build_exitcode -eq 0)
+{
+    Write-Host MSBuild finished. Running...
+    dotnet run --no-build -- --update $args
+    cd ..
+    exit $LastExitCode
+}
+else
+{
+    Write-Host MSBuild failed with exitcode $build_exitcode.
+    cd ..
+    exit $build_exitcode
+}

--- a/scripts/run-benchmark
+++ b/scripts/run-benchmark
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ProtoshiftBenchmark
+cd Tests/ProtoshiftBenchmark
 dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then

--- a/scripts/run-benchmark
+++ b/scripts/run-benchmark
@@ -5,7 +5,7 @@ dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...
-    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
+    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $@
     exit $?
 else
     echo MSBuild failed with exitcode $build_exitcode.

--- a/scripts/run-benchmark-debug
+++ b/scripts/run-benchmark-debug
@@ -2,13 +2,13 @@
 
 cd Tests/ProtoshiftBenchmark
 echo "This script is used for attaching a debugger on the Benchmark program. Please don't forget this!"
-dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
+dotnet build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...
     echo "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
     export COMPLUS_ForceENC=1
-    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- $@
+    dotnet run --no-build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- $@
     exit $?
 else
     echo MSBuild failed with exitcode $build_exitcode.

--- a/scripts/run-benchmark-debug
+++ b/scripts/run-benchmark-debug
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-cd ProtoshiftBenchmark
+cd Tests/ProtoshiftBenchmark
+echo "This script is used for attaching a debugger on the Benchmark program. Please don't forget this!"
 dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...
+    echo "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
     dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
     exit $?
 else

--- a/scripts/run-benchmark-debug
+++ b/scripts/run-benchmark-debug
@@ -7,7 +7,8 @@ build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...
     echo "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
-    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $@
+    export COMPLUS_ForceENC=1
+    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- $@
     exit $?
 else
     echo MSBuild failed with exitcode $build_exitcode.

--- a/scripts/run-benchmark-debug
+++ b/scripts/run-benchmark-debug
@@ -7,7 +7,7 @@ build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...
     echo "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
-    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
+    dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $@
     exit $?
 else
     echo MSBuild failed with exitcode $build_exitcode.

--- a/scripts/run-benchmark-debug.ps1
+++ b/scripts/run-benchmark-debug.ps1
@@ -6,7 +6,8 @@ if ($build_exitcode -eq 0)
 {
     Write-Host MSBuild finished. Running...
     Write-Host "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
-    dotnet run --no-build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
+    $env:COMPLUS_ForceENC=1
+    dotnet run --no-build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- $args
     cd ..\..
     exit $LastExitCode
 }

--- a/scripts/run-benchmark-debug.ps1
+++ b/scripts/run-benchmark-debug.ps1
@@ -1,0 +1,18 @@
+cd Tests\ProtoshiftBenchmark
+Write-Host "This script is used for attaching a debugger on the Benchmark program. Please don't forget this!"
+dotnet build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
+$build_exitcode = $LastExitCode
+if ($build_exitcode -eq 0)
+{
+    Write-Host MSBuild finished. Running...
+    Write-Host "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
+    dotnet run --no-build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
+    cd ..
+    exit $LastExitCode
+}
+else
+{
+    Write-Host MSBuild failed with exitcode $build_exitcode.
+    cd ..
+    exit $build_exitcode
+}

--- a/scripts/run-benchmark-debug.ps1
+++ b/scripts/run-benchmark-debug.ps1
@@ -7,12 +7,12 @@ if ($build_exitcode -eq 0)
     Write-Host MSBuild finished. Running...
     Write-Host "Please, attach a debugger now. Project is named as 'ProtoshiftBenchmark'."
     dotnet run --no-build --configuration Debug --property:DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bDEBUG%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
-    cd ..
+    cd ..\..
     exit $LastExitCode
 }
 else
 {
     Write-Host MSBuild failed with exitcode $build_exitcode.
-    cd ..
+    cd ..\..
     exit $build_exitcode
 }

--- a/scripts/run-benchmark.ps1
+++ b/scripts/run-benchmark.ps1
@@ -5,12 +5,12 @@ if ($build_exitcode -eq 0)
 {
     Write-Host MSBuild finished. Running...
     dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
-    cd ..
+    cd ..\..
     exit $LastExitCode
 }
 else
 {
     Write-Host MSBuild failed with exitcode $build_exitcode.
-    cd ..
+    cd ..\..
     exit $build_exitcode
 }

--- a/scripts/run-benchmark.ps1
+++ b/scripts/run-benchmark.ps1
@@ -1,13 +1,16 @@
-#!/bin/bash
-
-cd ProtoshiftBenchmark
+cd Tests\ProtoshiftBenchmark
 dotnet build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK
-build_exitcode=$?
-if [ $build_exitcode == 0 ]; then
-    echo MSBuild finished. Running...
+$build_exitcode = $LastExitCode
+if ($build_exitcode -eq 0)
+{
+    Write-Host MSBuild finished. Running...
     dotnet run --no-build --configuration Release --property:DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK -- --extra-property "DefineConstants=TRACE%3bRELEASE%3bNET%3bNET6_0%3bNETCOREAPP%3bMIHOMO_KCP%3bPROTOSHIFT_BENCHMARK" $args
-    exit $?
+    cd ..
+    exit $LastExitCode
+}
 else
-    echo MSBuild failed with exitcode $build_exitcode.
+{
+    Write-Host MSBuild failed with exitcode $build_exitcode.
+    cd ..
     exit $build_exitcode
-fi
+}

--- a/scripts/run-rel
+++ b/scripts/run-rel
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd csharp-Protoshift
-dotnet build
+dotnet build --configuration Release
 build_exitcode=$?
 if [ $build_exitcode == 0 ]; then
     echo MSBuild finished. Running...

--- a/scripts/run-rel
+++ b/scripts/run-rel
@@ -11,4 +11,3 @@ else
     echo MSBuild failed with exitcode $build_exitcode.
     exit $build_exitcode
 fi
-

--- a/scripts/run-rel.ps1
+++ b/scripts/run-rel.ps1
@@ -1,5 +1,5 @@
 cd csharp-Protoshift
-dotnet build
+dotnet build --configuration Release
 $build_exitcode = $LastExitCode
 if ($build_exitcode -eq 0)
 {


### PR DESCRIPTION
## Description

### General bugfixs

- Fixed an issue whereby Protos can't clone properly on some devices because of Git `safe.directory` configurations.
- Fixed an issue whereby `csharp-Protoshift-Replay` can't launch because the resources directory is not adjusted. 
- Fixed an issue whereby `ProtoshiftBenchmark`'s command line option `--orderby-packet-speed` actually didn't work.
- Supported initiated handlers JIT compile for `csharp-Protoshift-Replay`.
- Supported public variable `Resources.BasePath` to get the path where resources are loaded.
- Fixed an issue whereby running `ProtoshiftBenchmark` or `csharp-Protoshift-Replay` fails for raising grammar error.
- Supported `-f, --source-file` and `--fully-replay-packet-time` option for `csharp-Protoshift-Replay`.
- Optimized and added more scripts of running `ProtoshiftBenchmark`.
- Fixed the issue whereby `HandlerGenerator` being unable to fetch and restore Protos due to the Git `safe.directory` configuration in certain environments.
- Fixed the issue whereby `HandlerGenerator` being unable to fetch and restore Protos when there are spaces in the project directory.
- Fixed the issue whereby `csharp-Protoshift` being unable to invoke `luac` to compile Windy lua scripts when there are spaces in the project directory.
- Fixed the issue whereby `HandlerGenerator` displaying abnormal exit prompt text when the external application invocation fails.
- Fixed the issue whereby `HandlerGenerator` being unable to correctly invoke Powershell in Windows to execute post-generation scripts when there are spaces in the project directory.

### On-start handlers JIT Compile

#### Summary

Being a server-like implemention, csharp-Protoshift always tends to finish high time-costing process on startup, which can help reduce the Protoshift delay and provide better playing experience.

#### Principle

Below is what initiated JIT methods are expected to do:

- Firstly, create an instance whose all fields has **non-empty / non-zero values**.
- Serialize it to all supported data types (`byte[]`, `ByteString`, etc..), then give it to `NewShiftToOld` methods.
- Use the results to invoke `OldShiftToNew` methods.

This will trigger the JIT of: 

- Parse methods of `MessageParser`;
- `NewShiftToOld`, `OldShiftToNew` and all its reloads;
- The getter, setter of Protobuf messages.

#### Breaking Changes

1. For those who is using custom handlers, this change requires them to modify some code for JIT API. If that's your case, you may need to:
   - Comment your custom handlers in `HandlerGenerator/Gencode_Configuration/handlerignore.txt` and use `./update` to rebuild;
   - Find the code of these protos, and copy code in subregion `JIT API` (whose parent is region `Protocol Shift`) to your custom handler code;
   - Uncomment them in `handlerignore.txt` and regenerate (to delete duplicate handlers).

2. Changed the definition of `NewShiftToOld(ReadOnlySpan<byte>)` and `OldShiftToNew(ReadOnlySpan<byte>)`. Switched its returning value from `byte[]` to `IMessage?`.   
   The reason for this is that the reload of `Span` paramter is often used for outer buffer allocation (implementing something like non-GC-alloc). So the new version directly returns `IMessage`, which supports `CalculateSize()`, `WriteTo(Span<byte>)`. The memory allocation can only be used outside manually.
   You're recommended to rapidly adjust your code by:
   - Open the project in VSCode, and select the second view "Search" (or press Ctrl+Shift+F).
   - Paste the below code to "Search" box:
     ```cs
             public override byte[] NewShiftToOld(ReadOnlySpan<byte> span)
             {
                 var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
                 return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
             }
     ```
   - Paste the below code to "Replace" box:
     ```cs
             public override IMessage? NewShiftToOld(ReadOnlySpan<byte> span)
             {
                 var rtn = NewShiftToOld(newproto_parser_base.ParseFrom(span));
                 return rtn;
             }
     ```
    - Click "Replace All" and confirm.
   - Paste the below code to "Search" box:
     ```cs
             public override byte[] OldShiftToNew(ReadOnlySpan<byte> span)
             {
                 var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
                 return rtn == null ? Array.Empty<byte>() : rtn.ToByteArray();
             }
     ```
   - Paste the below code to "Replace" box:
     ```cs
             public override IMessage? OldShiftToNew(ReadOnlySpan<byte> span)
             {
                 var rtn = OldShiftToNew(oldproto_parser_base.ParseFrom(span));
                 return rtn;
             }
     ```
    - Click "Replace All" and confirm.

For an example of the 2 below breaking changes, please view [diff - ProtoshiftHandlers/SpecialHandlers/HandlerAbilityInvokeEntry.cs](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36/files#diff-3e297a1f09b6d7a674786186104782cacf14ac44704b0d158e1e06d6eb9c9d19).

All official custom handlers are already adjusted with new standard. You can view [diff - ProtoshiftHandlers/Example/Generated_std/HandlerExampleProto.cs](https://github.com/YYHEggEgg/csharp-Protoshift/pull/36/files#diff-e3c5fa24f67e1f02a806e2ca42554bf518fde6ad71cdb9b87ba7d6876aa94990) to get informed of the actual Handler standard changes.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/YYHEggEgg/csharp-Protoshift/blob/main/CONTRIBUTING.md) and [Code of conduct](https://github.com/YYHEggEgg/csharp-Protoshift/blob/main/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.