### PR TITLE
Fix the notice of 'You are recommended to update' not showing up

### DIFF
--- a/csharp-Protoshift/Program.cs
+++ b/csharp-Protoshift/Program.cs
@@ -6,6 +6,7 @@ using csharp_Protoshift.MhyKCP.Proxy;
 using csharp_Protoshift.resLoader;
 using csharp_Protoshift.SkillIssue;
 using System.Net;
+using System.Reflection;
 using YYHEggEgg.Logger;
 
 namespace csharp_Protoshift
@@ -33,7 +34,8 @@ namespace csharp_Protoshift
                 is_PipeSeparated_Format: false,
                 enable_Detailed_Time: true
                 ));
-            Log.Info("csharp-Protoshift v1.0.0", "Entry");
+            string? version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3);
+            Log.Info($"csharp-Protoshift v{version ?? "<unknown>"}", "Entry");
             Log.Info("Written by YYHEggEgg#6167, https://github.com/YYHEggEgg.", "Entry");
             ConsoleWrapper.ShutDownRequest += Tools.ExitOnLaunching;
             ResourcesLoader.CheckForRequiredResources();

--- a/csharp-Protoshift/Tools.cs
+++ b/csharp-Protoshift/Tools.cs
@@ -21,22 +21,6 @@ namespace csharp_Protoshift
     {
         public static string ProgramPath => AppDomain.CurrentDomain.BaseDirectory;
 
-        static Random ran = new Random();
-
-        /// <summary>
-        /// Generate a random string with length of [len]. 
-        /// </summary>
-        public static string RandomStr(int len)
-        {
-            string charset = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890";
-            string res = "";
-            while (len-- > 0)
-            {
-                res += charset[ran.Next(0, 61)];
-            }
-            return res;
-        }
-
         public async static Task ExecuteProcess(string path, string args)
         {
             var p = Process.Start(path, args);
@@ -215,13 +199,13 @@ namespace csharp_Protoshift
 
         private class VersionInfo
         {
-            public string? CurrentVersion;
+            public string? CurrentVersion { get; set; }
             /// <summary>
             /// Only when the current version is earlier
             /// than this will the update notice be raised
             /// as a warning.
             /// </summary>
-            public string? EarliestStableVersion;
+            public string? EarliestStableVersion { get; set; }
         }
 
         private static string GitHubRestApiUserAgent =>


### PR DESCRIPTION
## Description

Each time this program launches, it sends a request to GitHub API of the releases to check update; if a newer version is detected, a log will be printed:

```log
<Info:UpdateCheck> The new version: v1.0.2.1 of csharp-Protoshift is avaliable!
```

However, if the release is tagged 'recommended update' in `versioninfo.json` from Release Assets, it should print a notice 'You are recommended to update to this version' (but not working actually).

This PR mainly fixes this bug. Meanwhile, the shown current version on startup is corrected (instead of hardcoding).

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/YYHEggEgg/csharp-Protoshift/blob/main/CONTRIBUTING.md) and [Code of conduct](https://github.com/YYHEggEgg/csharp-Protoshift/blob/main/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.